### PR TITLE
Add BatchExportCommand 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation 'org.apache.commons:commons-csv:1.8'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/src/main/java/seedu/address/logic/commands/BatchExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BatchExportCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.employee.Employee;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+public class BatchExportCommand extends Command{
+    public static final String COMMAND_WORD = "batchexport";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Exports the database to a CSV file.\n"
+            + "Parameters: FILENAME (the exported CSV file will be saved in the data folder)\n"
+            + "Example: " + COMMAND_WORD + " exported_database.csv";
+    public static final String MESSAGE_WORKS = "Database exported to %s.";
+
+    private final String fileName;
+    private final Path filePath;
+
+    public BatchExportCommand(String fileName) {
+        requireAllNonNull(fileName);
+        this.fileName = fileName;
+        this.filePath = Paths.get("data", this.fileName);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        try {
+            exportToCsv(model, filePath);
+        } catch (IOException e) {
+            throw new CommandException("Error exporting data: " + e.getMessage());
+        }
+
+        return new CommandResult(String.format(MESSAGE_WORKS, fileName));
+    }
+
+    private void exportToCsv(Model model, Path filePath) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath.toFile()));
+             CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
+                     .withHeader("Name", "Phone", "Email", "Address", "Tags"))) {
+
+            List<Employee> employeeList = model.getExecutiveProDb().getEmployeeList();
+
+            for (Employee employee : employeeList) {
+                csvPrinter.printRecord(
+                        employee.getName().fullName,
+                        employee.getPhone().value,
+                        employee.getEmail().value,
+                        employee.getAddress().value,
+                        employee.getTags().stream().map(tag -> tag.tagName).collect(Collectors.joining(", "))
+                );
+            }
+
+            csvPrinter.flush();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/BatchExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BatchExportCommandParser.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.BatchExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+
+public class BatchExportCommandParser implements Parser<BatchExportCommand> {
+
+    public BatchExportCommand parse(String args) throws ParseException {
+        try
+        {
+            String fileName = ParserUtil.parseExport(args);
+            return new BatchExportCommand(fileName);
+        } catch (ParseException exception)
+        {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BatchExportCommand.MESSAGE_USAGE), exception);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ExecutiveProParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExecutiveProParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.BatchAddCommand;
+import seedu.address.logic.commands.BatchExportCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -53,7 +54,10 @@ public class ExecutiveProParser {
         case BatchAddCommand.COMMAND_WORD:
             return new BatchAddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
+        case BatchExportCommand.COMMAND_WORD:
+            return new BatchExportCommandParser().parse(arguments);
+
+            case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -8,6 +9,8 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.BatchExportCommand;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ThemeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.employee.Address;
@@ -178,4 +181,14 @@ public class ParserUtil {
         }
         return trimmedFileName;
     }
+    public static String parseExport(String filename) throws ParseException {
+        requireNonNull(filename);
+        String trimmedFileName = filename.trim();
+        System.out.println(trimmedFileName);
+        if (trimmedFileName.length() < 1){
+            throw new ParseException("Fail");
+        }
+        return trimmedFileName;
+    }
+
 }


### PR DESCRIPTION
HR managers can export the database into a csv file, update BatchExportCommandParser and Parser class accordingly, fixes #129 